### PR TITLE
Add support for parentheses in uri (master)

### DIFF
--- a/open-uri-context-menu.py
+++ b/open-uri-context-menu.py
@@ -27,7 +27,7 @@ import subprocess
 import string
 
 ACCEPTED_SCHEMES = ['file', 'ftp', 'sftp', 'smb', 'dav', 'davs', 'ssh', 'http', 'https']
-RE_DELIM = re.compile(r'[\w#/\?:%@&\=\+\.\\~-]+', re.UNICODE|re.MULTILINE)
+RE_DELIM = re.compile(r'[\w#/\?:\(\)%@&\=\+\.\\~-]+', re.UNICODE|re.MULTILINE)
 RE_URI_RFC2396 = re.compile("((([a-zA-Z][0-9a-zA-Z+\\-\\.]*):)?/{0,2}([0-9a-zA-Z;:,/\?@&=\+\$\.\-_!~\*'\(\)%]+))?(#[0-9a-zA-Z;,/\?:@&\=+$\.\\-_!~\*'\(\)%]+)?")
 
 class OpenURIContextMenuPlugin(GObject.Object, Gedit.WindowActivatable):


### PR DESCRIPTION
Since parentheses are legal characters in uri's, the plugin should accept them. Here's an example that used to fail but now works with "Browse to".

https://m.costco.ca/T-Fal-20.8-L-(22-qt.)-Pressure-Cooker-Canner-.product.100340458.html

In case the v2 pull request doesn't get in, here's the same change in master.