### PR TITLE
Fix object has no attribute 'get_location'

### DIFF
--- a/open-uri-context-menu.py
+++ b/open-uri-context-menu.py
@@ -194,7 +194,7 @@ class OpenURIContextMenuPlugin(GObject.Object, Gedit.WindowActivatable):
 	def get_document_by_uri(self, uri):
 		docs = self.window.get_documents()
 		for d in docs [:]:
-			if d.get_location() == uri:
+			if d.get_file().get_location() == uri:
 				return d
 		return None
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "local/share/gedit/plugins/open-uri-context-menu.py", line 150, in on_open_uri_activate
    self.open_uri(uri)
  File "local/share/gedit/plugins/open-uri-context-menu.py", line 202, in open_uri
    doc = self.get_document_by_uri(uri)
  File "local/share/gedit/plugins/open-uri-context-menu.py", line 197, in get_document_by_uri
    if d.get_location() == uri:
AttributeError: 'Document' object has no attribute 'get_location'